### PR TITLE
Support light and opened icon variants

### DIFF
--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -164,10 +164,12 @@ Icon Source: https://github.com/vscode-icons/vscode-icons"
           (vscode-icon-default-folder))
       (vscode-icon-default-folder))))
 
-(defun vscode-icon-file (file)
-  "Get file icon given FILE."
+(defun vscode-icon-file (file &optional light)
+  "Get file icon given FILE.
+
+If LIGHT is t, try to use the light variant if it exists."
   (vscode-icon-if-let* ((filepath (vscode-icon-file-exists-p
-                                   (file-name-extension file))))
+                                   (file-name-extension file) light)))
       (vscode-icon-create-image filepath)
     (vscode-icon-if-let*
         ((val (or
@@ -176,7 +178,8 @@ Icon Source: https://github.com/vscode-icons/vscode-icons"
                (cdr (assoc file vscode-icon-file-alist))
                (cdr (assoc (file-name-extension file)
                            vscode-icon-file-alist)))))
-        (vscode-icon-if-let* ((filepath (vscode-icon-file-exists-p val)))
+        (vscode-icon-if-let* ((filepath (vscode-icon-file-exists-p
+                                         val light)))
             (vscode-icon-create-image filepath)
           (vscode-icon-default-file))
       (vscode-icon-default-file))))

--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -234,9 +234,13 @@ variant."
   (let ((scale (vscode-icon-get-scale vscode-icon-size)))
     (create-image filename 'png nil :scale scale :ascent 'center)))
 
-(defun vscode-icon-default-folder ()
-  "Return image for default folder."
-  (vscode-icon-create-image (expand-file-name "default_folder.png")))
+(defun vscode-icon-default-folder (&optional open)
+  "Return image for default folder.
+
+If OPEN is t, try to use the opened variant."
+  (vscode-icon-create-image
+   (expand-file-name (if open "default_folder_opened.png"
+                       "default_folder.png"))))
 
 (defun vscode-icon-default-file ()
   "Return image for default file."

--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -217,18 +217,17 @@ light variant if it exists."
                          vscode-icon-extra-icon-directory))))
     (vscode-icon-locate-file key dir-list nil '(".png") light nil)))
 
-(defun vscode-icon-dir-exists-p (key)
+(defun vscode-icon-dir-exists-p (key &optional light open)
   "Check if there is an icon for KEY.
 
-Return filepath of icon if so."
-  (let ((path-in-default-dir (expand-file-name (format "folder_type_%s.png" key)))
-        (path-in-extra-dir (expand-file-name (format "%d/folder_type_%s.png"
-                                                     vscode-icon-size key)
-                                             vscode-icon-extra-icon-directory)))
-    (cond
-     ((file-exists-p path-in-default-dir) path-in-default-dir)
-     ((file-exists-p path-in-extra-dir) path-in-extra-dir)
-     (:default nil))))
+Return filepath of icon if so. If LIGHT is t, try to use the
+light variant if it exists. If OPEN is t, try to use the opened
+variant."
+  (let ((dir-list (list default-directory
+                        (expand-file-name
+                         (number-to-string vscode-icon-size)
+                         vscode-icon-extra-icon-directory))))
+    (vscode-icon-locate-file key dir-list t '(".png") light open)))
 
 (defun vscode-icon-create-image (filename)
   "Helper method to create and return an image given FILENAME."

--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -205,18 +205,17 @@ EXTENSIONS is a list of extension to look for; it could include
              (locate-file filename-opened dir-list extensions))
         (locate-file filename dir-list extensions))))
 
-(defun vscode-icon-file-exists-p (key)
+(defun vscode-icon-file-exists-p (key &optional light)
   "Check if there is an icon for KEY.
 
-Return filepath of icon if so."
-  (let ((path-in-default-dir (expand-file-name (format "file_type_%s.png" key)))
-        (path-in-extra-dir (expand-file-name (format "%d/file_type_%s.png"
-                                                     vscode-icon-size key)
-                                             vscode-icon-extra-icon-directory)))
-    (cond
-     ((file-exists-p path-in-default-dir) path-in-default-dir)
-     ((file-exists-p path-in-extra-dir) path-in-extra-dir)
-     (:default nil))))
+
+Return filepath of icon if so. If LIGHT is t, try to use the
+light variant if it exists."
+  (let ((dir-list (list default-directory
+                        (expand-file-name
+                         (number-to-string vscode-icon-size)
+                         vscode-icon-extra-icon-directory))))
+    (vscode-icon-locate-file key dir-list nil '(".png") light nil)))
 
 (defun vscode-icon-dir-exists-p (key)
   "Check if there is an icon for KEY.

--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -138,8 +138,11 @@ This directory is searched when icons are being searched for in addition to
 
 ;; Implementation
 
-(defun vscode-icon-for-file (file)
+(defun vscode-icon-for-file (file &optional light open)
   "Return an vscode icon image given FILE.
+
+If LIGHT is t, try to use the light variant if it exists. If OPEN
+is t and the icons is a folder, try to use the opened variant.
 
 Icon Source: https://github.com/vscode-icons/vscode-icons"
   (let ((default-directory
@@ -148,8 +151,8 @@ Icon Source: https://github.com/vscode-icons/vscode-icons"
             (concat vscode-icon-dir
                     (number-to-string vscode-icon-size) "/"))))
     (if (file-directory-p file)
-        (vscode-icon-dir file)
-      (vscode-icon-file file))))
+        (vscode-icon-dir file light open)
+      (vscode-icon-file file light))))
 
 (defun vscode-icon-dir (file &optional light open)
   "Get directory icon given FILE.

--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -181,6 +181,30 @@ Icon Source: https://github.com/vscode-icons/vscode-icons"
           (vscode-icon-default-file))
       (vscode-icon-default-file))))
 
+(defun vscode-icon-locate-file (key dir-list directory-p extensions light open)
+  "Locate the icon for KEY in directories in DIR-LIST.
+
+If DIRECTORY-P is t, look for directory icons. If LIGHT is t, try
+to use the light variant if it exists. If OPEN is t and the icons
+is a folder, try to use the opened variant.
+
+Return the absolute path if found, nil if not.
+
+EXTENSIONS is a list of extension to look for; it could include
+\".png\" or \".svg\"."
+  (let* ((prefix (if directory-p "folder_type_" "file_type_"))
+         (filename (concat prefix key))
+         (filename-light (concat prefix "light_" key))
+         (filename-opened (concat prefix key "_opened"))
+         (filename-light-opened (concat prefix "light_" key "_opened")))
+    (or (and light open
+             (locate-file filename-light-opened dir-list extensions))
+        (and light
+             (locate-file filename-light dir-list extensions))
+        (and open
+             (locate-file filename-opened dir-list extensions))
+        (locate-file filename dir-list extensions))))
+
 (defun vscode-icon-file-exists-p (key)
   "Check if there is an icon for KEY.
 

--- a/vscode-icon.el
+++ b/vscode-icon.el
@@ -151,18 +151,22 @@ Icon Source: https://github.com/vscode-icons/vscode-icons"
         (vscode-icon-dir file)
       (vscode-icon-file file))))
 
-(defun vscode-icon-dir (file)
-  "Get directory icon given FILE."
+(defun vscode-icon-dir (file &optional light open)
+  "Get directory icon given FILE.
+
+If LIGHT is t, try to use the light variant if it exists. If OPEN
+is t and the icons is a folder, try to use the opened variant."
   (vscode-icon-if-let* ((filepath (vscode-icon-dir-exists-p
-                                   (file-name-base file))))
+                                   (file-name-base file) light open)))
       (vscode-icon-create-image filepath)
     (vscode-icon-if-let*
         ((val (cdr (assoc
                     (file-name-base file) vscode-icon-dir-alist))))
-        (vscode-icon-if-let* ((filepath (vscode-icon-dir-exists-p val)))
+        (vscode-icon-if-let* ((filepath (vscode-icon-dir-exists-p
+                                         val light open)))
             (vscode-icon-create-image filepath)
-          (vscode-icon-default-folder))
-      (vscode-icon-default-folder))))
+          (vscode-icon-default-folder open))
+      (vscode-icon-default-folder open))))
 
 (defun vscode-icon-file (file &optional light)
   "Get file icon given FILE.


### PR DESCRIPTION
How about something like this? This patch adds `light` and `open` optional arguments to `vscode-icon-for-file`. It falls back to normal variant if the special variant doesn't exists.